### PR TITLE
fix: Fix css layout for date

### DIFF
--- a/sass/css/blog.scss
+++ b/sass/css/blog.scss
@@ -39,6 +39,7 @@ main {
         }
         .date {
             color: var(--text-light-color);
+            flex: 0 0 auto;
         }
     }
 


### PR DESCRIPTION
<img width="412" alt="Screenshot 2025-02-18 at 11 10 00" src="https://github.com/user-attachments/assets/8f668cca-b55c-410b-9188-f5774627ce42" />
<img width="507" alt="Screenshot 2025-02-18 at 11 09 52" src="https://github.com/user-attachments/assets/e3683682-8165-4e85-b7e3-365415f266eb" />
<img width="503" alt="Screenshot 2025-02-18 at 11 09 42" src="https://github.com/user-attachments/assets/2108686c-505c-4857-9c75-882367d43a6b" />
